### PR TITLE
feat: customizable hook style (font, colors, corner radius, position)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1155,6 +1155,7 @@ class YTShortClipperApp(ctk.CTk):
             tts_model = self.config.get("tts_model", "tts-1")
             watermark_settings = self.config.get("watermark", {"enabled": False})
             credit_watermark_settings = self.config.get("credit_watermark", {"enabled": False})
+            hook_style_settings = self.config.get("hook_style", {})
             
             # Get face tracking mode from config (set in settings page)
             face_tracking_mode = self.config.get("face_tracking_mode", "opencv")
@@ -1177,6 +1178,7 @@ class YTShortClipperApp(ctk.CTk):
                 system_prompt=system_prompt,
                 watermark_settings=watermark_settings,
                 credit_watermark_settings=credit_watermark_settings,
+                hook_style_settings=hook_style_settings,
                 face_tracking_mode=face_tracking_mode,
                 mediapipe_settings=mediapipe_settings,
                 ai_providers=self.config.get("ai_providers"),
@@ -1532,6 +1534,7 @@ class YTShortClipperApp(ctk.CTk):
             tts_model = self.config.get("tts_model", "tts-1")
             watermark_settings = self.config.get("watermark", {"enabled": False})
             credit_watermark_settings = self.config.get("credit_watermark", {"enabled": False})
+            hook_style_settings = self.config.get("hook_style", {})
             face_tracking_mode = self.config.get("face_tracking_mode", "opencv")
             mediapipe_settings = self.config.get("mediapipe_settings", {
                 "lip_activity_threshold": 0.15,
@@ -1554,6 +1557,7 @@ class YTShortClipperApp(ctk.CTk):
                 system_prompt=system_prompt,
                 watermark_settings=watermark_settings,
                 credit_watermark_settings=credit_watermark_settings,
+                hook_style_settings=hook_style_settings,
                 face_tracking_mode=face_tracking_mode,
                 mediapipe_settings=mediapipe_settings,
                 ai_providers=self.config.get("ai_providers"),

--- a/clipper_core.py
+++ b/clipper_core.py
@@ -67,6 +67,21 @@ class SubtitleNotFoundError(Exception):
         self.session_dir = session_dir
 
 
+def _hex_to_rgb(hex_color: str):
+    """Convert a #RRGGBB or #RGB string to an (R, G, B) tuple. Falls back to white on bad input."""
+    if not isinstance(hex_color, str):
+        return (255, 255, 255)
+    s = hex_color.strip().lstrip("#")
+    if len(s) == 3:
+        s = "".join(ch * 2 for ch in s)
+    if len(s) != 6:
+        return (255, 255, 255)
+    try:
+        return (int(s[0:2], 16), int(s[2:4], 16), int(s[4:6], 16))
+    except ValueError:
+        return (255, 255, 255)
+
+
 class AutoClipperCore:
     """Core processing logic for Auto Clipper"""
     
@@ -82,6 +97,7 @@ class AutoClipperCore:
         system_prompt: str = None,
         watermark_settings: dict = None,
         credit_watermark_settings: dict = None,
+        hook_style_settings: dict = None,
         face_tracking_mode: str = "opencv",
         mediapipe_settings: dict = None,
         ai_providers: dict = None,
@@ -139,6 +155,7 @@ class AutoClipperCore:
         self.system_prompt = system_prompt or self.get_default_prompt()
         self.watermark_settings = watermark_settings or {"enabled": False}
         self.credit_watermark_settings = credit_watermark_settings or {"enabled": False}
+        self.hook_style_settings = hook_style_settings or {}
         self.channel_name = ""  # Will be set after download
         self.face_tracking_mode = face_tracking_mode
         self.mediapipe_settings = mediapipe_settings or {
@@ -3928,14 +3945,6 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
         # Create hook video in our temp directory
         hook_video = str(self.temp_dir / f"hook_{int(time.time() * 1000)}.mp4")
         
-        # Create text file for drawtext filter (avoid escaping issues)
-        text_file = str(self.temp_dir / f"hook_text_{int(time.time() * 1000)}.txt")
-        
-        # Write text lines to file
-        text_content = '\n'.join(lines)
-        with open(text_file, 'w', encoding='utf-8') as f:
-            f.write(text_content)
-        
         # Use a simpler approach: create static image with text, then combine with audio
         # This avoids complex FFmpeg filter escaping issues
         
@@ -3966,121 +3975,140 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
         if not os.path.exists(bg_video) or os.path.getsize(bg_video) < 1000:
             raise Exception("Background video was not created properly")
         
-        # Copy font to temp dir to avoid path issues in FFmpeg filter
-        import shutil
-        temp_font = str(self.temp_dir / "arial_bold.ttf")
-        if not os.path.exists(temp_font):
-            font_src = self._find_system_font_bold()
-            if font_src:
-                shutil.copy(font_src, temp_font)
-        
-        # Now add text overlays one by one
-        current_video = bg_video
-        line_height = 85
-        font_size = 58
-        total_text_height = len(lines) * line_height
-        start_y = (height // 3) - (total_text_height // 2)
-        
-        for i, line in enumerate(lines):
-            # Normalize unicode characters
-            normalized_line = line.encode('ascii', 'ignore').decode('ascii')
-            if not normalized_line.strip():
-                normalized_line = line.replace('\u2026', '...').replace('\u2013', '-').replace('\u2018', "'").replace('\u2019', "'").replace('\u201c', '"').replace('\u201d', '"')
-            
-            y_pos = start_y + (i * line_height)
-            
-            next_video = str(self.temp_dir / f"hook_text_{int(time.time() * 1000)}_{i}.mp4")
-            
-            # Use OpenCV to add text overlay instead of FFmpeg drawtext
-            # This avoids all Windows path escaping issues
-            self.log(f"Adding text overlay with OpenCV: {normalized_line}")
-            
-            # Read input video
-            cap = cv2.VideoCapture(current_video)
-            fps = int(cap.get(cv2.CAP_PROP_FPS))
-            width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
-            height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-            
-            # Setup video writer
-            fourcc = cv2.VideoWriter_fourcc(*'mp4v')
-            out = cv2.VideoWriter(next_video, fourcc, fps, (width, height))
-            
-            # Process each frame
-            frame_count = 0
-            while True:
-                ret, frame = cap.read()
-                if not ret:
-                    break
-                
-                # Add text overlay using cv2.putText
-                # Calculate text size for centering
-                font = cv2.FONT_HERSHEY_SIMPLEX  # Fixed: use SIMPLEX instead of BOLD
-                font_scale = 2.0
-                thickness = 4
-                
-                # Get text size
-                (text_width, text_height), baseline = cv2.getTextSize(
-                    normalized_line, font, font_scale, thickness
+        # === Render hook overlay using PIL (supports user-customized font, colors, corners) ===
+        from PIL import Image, ImageDraw, ImageFont
+
+        style = self.hook_style_settings or {}
+        font_size_frac = float(style.get("font_size", 0.054))
+        font_color_hex = style.get("font_color", "#FFD700")
+        bg_color_hex = style.get("bg_color", "#FFFFFF")
+        corner_radius = int(style.get("corner_radius", 0))
+        pos_x = float(style.get("position_x", 0.5))
+        pos_y = float(style.get("position_y", 0.333))
+        user_font_path = style.get("font_path") or ""
+
+        # Resolve font path with sensible fallbacks
+        font_candidates = [user_font_path, self._find_system_font_bold()]
+        pil_font = None
+        font_px = max(20, int(font_size_frac * width))
+        for candidate in font_candidates:
+            if not candidate or not os.path.exists(candidate):
+                continue
+            try:
+                pil_font = ImageFont.truetype(candidate, font_px)
+                self.log(f"  Hook font: {candidate} @ {font_px}px")
+                break
+            except Exception as e:
+                self.log(f"  ⚠ Failed to load font {candidate}: {e}")
+        if pil_font is None:
+            self.log("  ⚠ No usable TTF font found, using PIL default (will look basic)")
+            pil_font = ImageFont.load_default()
+
+        font_color_rgb = _hex_to_rgb(font_color_hex)
+        bg_color_rgb = _hex_to_rgb(bg_color_hex)
+
+        # Per-line geometry
+        padding = max(10, int(font_px * 0.22))
+        line_spacing = max(6, int(font_px * 0.25))
+
+        line_metrics = []
+        for line in lines:
+            try:
+                bbox = pil_font.getbbox(line)
+            except AttributeError:
+                w, h = pil_font.getsize(line)
+                bbox = (0, 0, w, h)
+            text_w = bbox[2] - bbox[0]
+            text_h = bbox[3] - bbox[1]
+            line_metrics.append({
+                "text": line,
+                "bbox": bbox,
+                "box_w": text_w + padding * 2,
+                "box_h": text_h + padding * 2,
+            })
+
+        total_h = sum(m["box_h"] for m in line_metrics)
+        if len(line_metrics) > 1:
+            total_h += line_spacing * (len(line_metrics) - 1)
+
+        center_x = int(pos_x * width)
+        center_y = int(pos_y * height)
+        block_top = center_y - total_h // 2
+
+        # Compose the static overlay (transparent everywhere except the hook boxes)
+        overlay_img = Image.new("RGBA", (width, height), (0, 0, 0, 0))
+        draw = ImageDraw.Draw(overlay_img)
+
+        cur_y = block_top
+        for m in line_metrics:
+            box_w = m["box_w"]
+            box_h = m["box_h"]
+            box_x1 = center_x - box_w // 2
+            box_y1 = cur_y
+            box_x2 = box_x1 + box_w
+            box_y2 = box_y1 + box_h
+
+            if corner_radius > 0 and hasattr(draw, "rounded_rectangle"):
+                # Clamp radius so it never exceeds half the smaller dimension
+                r = min(corner_radius, box_w // 2, box_h // 2)
+                draw.rounded_rectangle(
+                    [box_x1, box_y1, box_x2, box_y2],
+                    radius=r,
+                    fill=(*bg_color_rgb, 255),
                 )
-                
-                # Calculate position (centered horizontally, at y_pos vertically)
-                text_x = (width - text_width) // 2
-                text_y = y_pos + text_height
-                
-                # Draw white background box
-                box_padding = 12
-                box_x1 = text_x - box_padding
-                box_y1 = text_y - text_height - box_padding
-                box_x2 = text_x + text_width + box_padding
-                box_y2 = text_y + baseline + box_padding
-                
-                # Draw semi-transparent white box
-                overlay = frame.copy()
-                cv2.rectangle(overlay, (box_x1, box_y1), (box_x2, box_y2), (255, 255, 255), -1)
-                cv2.addWeighted(overlay, 0.95, frame, 0.05, 0, frame)
-                
-                # Draw yellow/gold text (#FFD700 = RGB(255, 215, 0))
-                cv2.putText(frame, normalized_line, (text_x, text_y),
-                           font, font_scale, (0, 215, 255), thickness, cv2.LINE_AA)
-                
-                out.write(frame)
-                frame_count += 1
-            
-            cap.release()
-            out.release()
-            
-            self.log(f"Processed {frame_count} frames with text overlay")
-            
-            # Verify output was created
-            if not os.path.exists(next_video) or os.path.getsize(next_video) < 1000:
-                raise Exception(f"Text overlay video {i} was not created properly")
-            
-            # Clean up previous temp file
-            if current_video != bg_video:
-                try:
-                    os.unlink(current_video)
-                except:
-                    pass
-            
-            current_video = next_video
-        
-        # Re-encode OpenCV output to proper H.264 before adding audio using GPU/CPU encoder
-        # OpenCV mp4v codec is not compatible with copy codec
-        reencoded_video = str(self.temp_dir / f"hook_reenc_{int(time.time() * 1000)}.mp4")
+            else:
+                draw.rectangle(
+                    [box_x1, box_y1, box_x2, box_y2],
+                    fill=(*bg_color_rgb, 255),
+                )
+
+            # PIL draws text at the top-left of the glyph bounding box;
+            # subtract bbox[0]/[1] so the glyphs sit cleanly inside the padding.
+            text_x = box_x1 + padding - m["bbox"][0]
+            text_y = box_y1 + padding - m["bbox"][1]
+            draw.text(
+                (text_x, text_y),
+                m["text"],
+                font=pil_font,
+                fill=(*font_color_rgb, 255),
+            )
+
+            cur_y = box_y2 + line_spacing
+
+        overlay_png = str(self.temp_dir / f"hook_overlay_{int(time.time() * 1000)}.png")
+        overlay_img.save(overlay_png, "PNG")
+        progress_callback(0.4)
+
+        # Composite overlay on the (frozen) background video in one FFmpeg pass
+        overlay_video = str(self.temp_dir / f"hook_overlay_video_{int(time.time() * 1000)}.mp4")
         encoder_args = self.get_video_encoder_args()
-        reencode_cmd = [
+        overlay_cmd = [
             self.ffmpeg_path, "-y",
-            "-i", current_video,
+            "-i", bg_video,
+            "-i", overlay_png,
+            "-filter_complex", "[0:v][1:v]overlay=0:0[v]",
+            "-map", "[v]",
             *encoder_args,
             "-pix_fmt", "yuv420p",
-            "-an",  # No audio yet
-            reencoded_video
+            "-an",
+            overlay_video,
         ]
-        self.log_ffmpeg_command(reencode_cmd, "Re-encode Hook Text Overlay")
-        result = subprocess.run(reencode_cmd, capture_output=True, text=True, creationflags=SUBPROCESS_FLAGS)
+        self.log_ffmpeg_command(overlay_cmd, "Composite Hook Overlay (PIL)")
+        result = subprocess.run(overlay_cmd, capture_output=True, text=True, creationflags=SUBPROCESS_FLAGS)
         if result.returncode != 0:
-            self.log(f"Failed to re-encode OpenCV output: {result.stderr}")
-            raise Exception("Failed to re-encode text overlay video")
+            self.log(f"Failed to composite hook overlay: {result.stderr}")
+            raise Exception("Failed to composite hook overlay video")
+
+        if not os.path.exists(overlay_video) or os.path.getsize(overlay_video) < 1000:
+            raise Exception("Hook overlay video was not created properly")
+
+        progress_callback(0.55)
+
+        # Both names point at the same file so the rest of the pipeline (audio mux,
+        # cleanup) keeps working without further changes.
+        current_video = overlay_video
+        reencoded_video = overlay_video
+
         
         # Finally, add audio to re-encoded video
         cmd = [
@@ -4175,16 +4203,13 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
             progress_callback(1.0)
         
         # Cleanup
-        try:
-            os.unlink(tts_file)
-            os.unlink(hook_video)
-            os.unlink(main_reencoded)
-            os.unlink(concat_list)
-            os.unlink(text_file)
-            os.unlink(bg_video)
-            os.unlink(current_video)
-        except:
-            pass
+        for path in (tts_file, hook_video, main_reencoded, concat_list,
+                     bg_video, overlay_video, overlay_png):
+            try:
+                if path and os.path.exists(path):
+                    os.unlink(path)
+            except Exception:
+                pass
         
         return hook_duration
     

--- a/pages/settings/hook_style_settings.py
+++ b/pages/settings/hook_style_settings.py
@@ -1,0 +1,538 @@
+"""
+Hook Style Settings Sub-Page
+
+Lets the user customize how the hook scene at the start of each clip looks:
+font family, font color, background color, corner radius, and on-screen position.
+"""
+
+import tkinter as tk
+from tkinter import colorchooser
+
+import customtkinter as ctk
+
+from pages.settings.base_dialog import BaseSettingsSubPage
+from utils.font_scanner import (
+    get_font_names,
+    get_path_for_name,
+    find_default_font,
+)
+
+
+# Defaults match the previous hard-coded look (white BG, gold text, sharp corners)
+DEFAULT_FONT_COLOR = "#FFD700"
+DEFAULT_BG_COLOR = "#FFFFFF"
+DEFAULT_CORNER_RADIUS = 0
+DEFAULT_POS_X = 0.5      # horizontal center
+DEFAULT_POS_Y = 0.333    # 1/3 from top (matches the old start_y = height // 3)
+DEFAULT_FONT_SIZE = 0.054  # ~58 / 1080, expressed as fraction of video width
+
+
+class HookStyleSettingsSubPage(BaseSettingsSubPage):
+    """Sub-page for configuring the hook overlay style."""
+
+    # Canvas dimensions (9:16 aspect, scaled down)
+    CANVAS_W = 270
+    CANVAS_H = 480
+
+    def __init__(self, parent, config, on_save_callback, on_back_callback):
+        self.config = config
+        self.on_save_callback = on_save_callback
+
+        # Drag state
+        self.dragging = False
+        self.drag_offset_x = 0
+        self.drag_offset_y = 0
+
+        # Canvas item ids (so we can delete + redraw cleanly)
+        self.bg_item = None
+        self.text_item = None
+
+        super().__init__(parent, "Hook Style", on_back_callback)
+
+        self.create_content()
+        self.load_config()
+
+    # ------------------------------------------------------------------
+    # Layout
+    # ------------------------------------------------------------------
+    def create_content(self):
+        # Info note
+        ctk.CTkLabel(
+            self.content,
+            text="Customize the look of the opening hook scene. Drag the box on the preview to set position.",
+            font=ctk.CTkFont(size=11),
+            text_color="gray",
+            wraplength=600,
+            justify="left",
+        ).pack(anchor="w", pady=(0, 15))
+
+        # Two-column layout: preview on the left, controls on the right
+        body = ctk.CTkFrame(self.content, fg_color="transparent")
+        body.pack(fill="both", expand=True)
+
+        # --- Preview column ---
+        preview_col = ctk.CTkFrame(body, fg_color="transparent")
+        preview_col.pack(side="left", padx=(0, 20), anchor="n")
+
+        ctk.CTkLabel(
+            preview_col,
+            text="Preview",
+            font=ctk.CTkFont(size=13, weight="bold"),
+        ).pack(anchor="w", pady=(0, 5))
+
+        canvas_frame = ctk.CTkFrame(preview_col, fg_color=("gray85", "gray20"))
+        canvas_frame.pack()
+
+        self.canvas = tk.Canvas(
+            canvas_frame,
+            width=self.CANVAS_W,
+            height=self.CANVAS_H,
+            bg="#1a1a1a",
+            highlightthickness=1,
+            highlightbackground="gray",
+        )
+        self.canvas.pack(padx=10, pady=10)
+
+        # 9:16 frame outline + label
+        self.canvas.create_rectangle(
+            0, 0, self.CANVAS_W, self.CANVAS_H, outline="gray", width=2
+        )
+        self.canvas.create_text(
+            self.CANVAS_W // 2,
+            self.CANVAS_H - 20,
+            text="9:16 Video Preview",
+            fill="gray50",
+            font=("Arial", 10),
+        )
+
+        # Drag handlers
+        self.canvas.bind("<Button-1>", self._on_canvas_click)
+        self.canvas.bind("<B1-Motion>", self._on_canvas_drag)
+        self.canvas.bind("<ButtonRelease-1>", self._on_canvas_release)
+
+        ctk.CTkLabel(
+            preview_col,
+            text="Tip: drag the hook box to reposition.",
+            font=ctk.CTkFont(size=10),
+            text_color="gray",
+        ).pack(anchor="w", pady=(8, 0))
+
+        # --- Controls column ---
+        controls = ctk.CTkFrame(body, fg_color="transparent")
+        controls.pack(side="left", fill="both", expand=True, anchor="n")
+
+        # Font family
+        ctk.CTkLabel(
+            controls, text="Font", font=ctk.CTkFont(size=13, weight="bold")
+        ).pack(anchor="w", pady=(0, 5))
+
+        font_names = get_font_names()
+        if not font_names:
+            font_names = ["Arial"]
+        self.font_var = ctk.StringVar(value=font_names[0])
+        self.font_dropdown = ctk.CTkComboBox(
+            controls,
+            values=font_names,
+            variable=self.font_var,
+            command=lambda _v: self._update_preview(),
+            state="readonly",
+            height=36,
+        )
+        self.font_dropdown.pack(fill="x", pady=(0, 15))
+
+        # Font size (as fraction of video width)
+        ctk.CTkLabel(
+            controls, text="Font Size", font=ctk.CTkFont(size=13, weight="bold")
+        ).pack(anchor="w", pady=(0, 5))
+        size_row = ctk.CTkFrame(controls, fg_color="transparent")
+        size_row.pack(fill="x", pady=(0, 15))
+        self.font_size_var = ctk.DoubleVar(value=DEFAULT_FONT_SIZE)
+        ctk.CTkSlider(
+            size_row,
+            from_=0.025,
+            to=0.10,
+            variable=self.font_size_var,
+            command=lambda _v: self._update_preview(),
+            number_of_steps=30,
+        ).pack(side="left", fill="x", expand=True, padx=(0, 10))
+        self.font_size_label = ctk.CTkLabel(size_row, text="5.4%", width=50, anchor="e")
+        self.font_size_label.pack(side="right")
+
+        # Font color
+        ctk.CTkLabel(
+            controls, text="Font Color", font=ctk.CTkFont(size=13, weight="bold")
+        ).pack(anchor="w", pady=(0, 5))
+        font_color_row = ctk.CTkFrame(controls, fg_color="transparent")
+        font_color_row.pack(fill="x", pady=(0, 15))
+        self.font_color = DEFAULT_FONT_COLOR
+        self.font_color_swatch = tk.Frame(
+            font_color_row, bg=self.font_color, width=36, height=36,
+            highlightthickness=1, highlightbackground="gray",
+        )
+        self.font_color_swatch.pack(side="left", padx=(0, 10))
+        self.font_color_swatch.pack_propagate(False)
+        self.font_color_entry = ctk.CTkEntry(font_color_row, width=120, height=36)
+        self.font_color_entry.insert(0, self.font_color)
+        self.font_color_entry.bind("<Return>", lambda _e: self._apply_color_entry("font"))
+        self.font_color_entry.bind("<FocusOut>", lambda _e: self._apply_color_entry("font"))
+        self.font_color_entry.pack(side="left", padx=(0, 10))
+        ctk.CTkButton(
+            font_color_row, text="Pick...", width=80, height=36,
+            command=lambda: self._pick_color("font"),
+        ).pack(side="left")
+
+        # Background color
+        ctk.CTkLabel(
+            controls, text="Background Color", font=ctk.CTkFont(size=13, weight="bold")
+        ).pack(anchor="w", pady=(0, 5))
+        bg_color_row = ctk.CTkFrame(controls, fg_color="transparent")
+        bg_color_row.pack(fill="x", pady=(0, 15))
+        self.bg_color = DEFAULT_BG_COLOR
+        self.bg_color_swatch = tk.Frame(
+            bg_color_row, bg=self.bg_color, width=36, height=36,
+            highlightthickness=1, highlightbackground="gray",
+        )
+        self.bg_color_swatch.pack(side="left", padx=(0, 10))
+        self.bg_color_swatch.pack_propagate(False)
+        self.bg_color_entry = ctk.CTkEntry(bg_color_row, width=120, height=36)
+        self.bg_color_entry.insert(0, self.bg_color)
+        self.bg_color_entry.bind("<Return>", lambda _e: self._apply_color_entry("bg"))
+        self.bg_color_entry.bind("<FocusOut>", lambda _e: self._apply_color_entry("bg"))
+        self.bg_color_entry.pack(side="left", padx=(0, 10))
+        ctk.CTkButton(
+            bg_color_row, text="Pick...", width=80, height=36,
+            command=lambda: self._pick_color("bg"),
+        ).pack(side="left")
+
+        # Corner radius
+        ctk.CTkLabel(
+            controls, text="Corner Radius (px)",
+            font=ctk.CTkFont(size=13, weight="bold"),
+        ).pack(anchor="w", pady=(0, 5))
+        ctk.CTkLabel(
+            controls,
+            text="In output video pixels (0 = sharp corners).",
+            font=ctk.CTkFont(size=10),
+            text_color="gray",
+        ).pack(anchor="w", pady=(0, 5))
+        radius_row = ctk.CTkFrame(controls, fg_color="transparent")
+        radius_row.pack(fill="x", pady=(0, 15))
+        self.corner_radius_var = ctk.IntVar(value=DEFAULT_CORNER_RADIUS)
+        ctk.CTkSlider(
+            radius_row,
+            from_=0,
+            to=80,
+            variable=self.corner_radius_var,
+            command=lambda _v: self._update_preview(),
+            number_of_steps=80,
+        ).pack(side="left", fill="x", expand=True, padx=(0, 10))
+        self.radius_label = ctk.CTkLabel(radius_row, text="0 px", width=60, anchor="e")
+        self.radius_label.pack(side="right")
+
+        # Position fields (read-only display, kept in sync with drag)
+        ctk.CTkLabel(
+            controls, text="Position", font=ctk.CTkFont(size=13, weight="bold")
+        ).pack(anchor="w", pady=(0, 5))
+        self.position_label = ctk.CTkLabel(
+            controls,
+            text="X: 50% Y: 33%",
+            font=ctk.CTkFont(size=11),
+            text_color="gray",
+        )
+        self.position_label.pack(anchor="w", pady=(0, 10))
+
+        ctk.CTkButton(
+            controls,
+            text="Reset to Default",
+            height=32,
+            fg_color=("gray70", "gray30"),
+            hover_color=("gray60", "gray35"),
+            command=self._reset_defaults,
+        ).pack(fill="x", pady=(5, 0))
+
+        # Save button at bottom of content
+        self.create_save_button(self.save_settings)
+
+        # Position state vars
+        self.pos_x_var = ctk.DoubleVar(value=DEFAULT_POS_X)
+        self.pos_y_var = ctk.DoubleVar(value=DEFAULT_POS_Y)
+
+        # Initial preview render
+        self.after(100, self._update_preview)
+
+    # ------------------------------------------------------------------
+    # Color handling
+    # ------------------------------------------------------------------
+    def _pick_color(self, target: str):
+        current = self.font_color if target == "font" else self.bg_color
+        rgb, hex_str = colorchooser.askcolor(color=current, title=f"Pick {target} color")
+        if hex_str:
+            self._set_color(target, hex_str)
+
+    def _apply_color_entry(self, target: str):
+        entry = self.font_color_entry if target == "font" else self.bg_color_entry
+        value = entry.get().strip()
+        if not value:
+            return
+        if not value.startswith("#"):
+            value = "#" + value
+        if not _is_valid_hex(value):
+            # Revert entry to current value
+            current = self.font_color if target == "font" else self.bg_color
+            entry.delete(0, "end")
+            entry.insert(0, current)
+            return
+        self._set_color(target, value.upper())
+
+    def _set_color(self, target: str, hex_color: str):
+        if target == "font":
+            self.font_color = hex_color
+            self.font_color_swatch.configure(bg=hex_color)
+            self.font_color_entry.delete(0, "end")
+            self.font_color_entry.insert(0, hex_color)
+        else:
+            self.bg_color = hex_color
+            self.bg_color_swatch.configure(bg=hex_color)
+            self.bg_color_entry.delete(0, "end")
+            self.bg_color_entry.insert(0, hex_color)
+        self._update_preview()
+
+    # ------------------------------------------------------------------
+    # Preview rendering
+    # ------------------------------------------------------------------
+    def _update_preview(self):
+        # Update labels
+        font_pct = self.font_size_var.get() * 100
+        self.font_size_label.configure(text=f"{font_pct:.1f}%")
+        self.radius_label.configure(text=f"{int(self.corner_radius_var.get())} px")
+        self.position_label.configure(
+            text=f"X: {int(self.pos_x_var.get() * 100)}%  Y: {int(self.pos_y_var.get() * 100)}%"
+        )
+
+        # Clear previous items
+        for item in (self.bg_item, self.text_item):
+            if item is not None:
+                self.canvas.delete(item)
+        self.bg_item = None
+        self.text_item = None
+
+        # Compute box geometry in canvas pixels.
+        # We map output video at 1080x1920 onto canvas 270x480 (scale 0.25).
+        scale = self.CANVAS_W / 1080.0
+
+        sample_text = "HOOK PREVIEW"
+        # Font size for preview (scaled). Tk needs an int.
+        video_font_px = int(self.font_size_var.get() * 1080)
+        preview_font_px = max(8, int(video_font_px * scale))
+
+        # Approximate text size on canvas: tk doesn't easily measure without rendering,
+        # so use rough heuristic: width ~= 0.55 * font_px * char_count
+        text_width = int(0.55 * preview_font_px * len(sample_text))
+        text_height = int(preview_font_px * 1.2)
+        padding = max(6, int(12 * scale * 4))  # padding in canvas px (visual approximation)
+
+        box_w = text_width + padding * 2
+        box_h = text_height + padding * 2
+
+        # Center the box on the position point
+        cx = int(self.pos_x_var.get() * self.CANVAS_W)
+        cy = int(self.pos_y_var.get() * self.CANVAS_H)
+        x1 = cx - box_w // 2
+        y1 = cy - box_h // 2
+        x2 = x1 + box_w
+        y2 = y1 + box_h
+
+        # Corner radius (canvas pixels). Slider value is in output video px.
+        radius_video = int(self.corner_radius_var.get())
+        radius_canvas = max(0, int(radius_video * scale))
+        # Clamp so radius can't exceed half the box
+        radius_canvas = min(radius_canvas, box_w // 2, box_h // 2)
+
+        # Draw rounded rectangle (or sharp if radius == 0)
+        if radius_canvas <= 0:
+            self.bg_item = self.canvas.create_rectangle(
+                x1, y1, x2, y2, fill=self.bg_color, outline=""
+            )
+        else:
+            self.bg_item = self._create_rounded_rect(
+                x1, y1, x2, y2, radius_canvas, fill=self.bg_color
+            )
+
+        # Draw text on top
+        # Tk font tuple: (family, size, style). Pull a usable family from display name.
+        family = _family_only(self.font_var.get())
+        try:
+            tk_font = (family, preview_font_px, "bold")
+        except Exception:
+            tk_font = ("Arial", preview_font_px, "bold")
+
+        self.text_item = self.canvas.create_text(
+            cx, cy,
+            text=sample_text,
+            fill=self.font_color,
+            font=tk_font,
+            anchor="center",
+        )
+
+    def _create_rounded_rect(self, x1, y1, x2, y2, r, **kwargs):
+        """Create a rounded rectangle on canvas using a smooth polygon."""
+        points = [
+            x1 + r, y1,
+            x2 - r, y1,
+            x2, y1,
+            x2, y1 + r,
+            x2, y2 - r,
+            x2, y2,
+            x2 - r, y2,
+            x1 + r, y2,
+            x1, y2,
+            x1, y2 - r,
+            x1, y1 + r,
+            x1, y1,
+        ]
+        return self.canvas.create_polygon(points, smooth=True, **kwargs)
+
+    # ------------------------------------------------------------------
+    # Drag handling
+    # ------------------------------------------------------------------
+    def _on_canvas_click(self, event):
+        if self.bg_item is None:
+            return
+        bbox = self.canvas.bbox(self.bg_item)
+        if not bbox:
+            return
+        if bbox[0] <= event.x <= bbox[2] and bbox[1] <= event.y <= bbox[3]:
+            self.dragging = True
+            cx = (bbox[0] + bbox[2]) / 2
+            cy = (bbox[1] + bbox[3]) / 2
+            self.drag_offset_x = event.x - cx
+            self.drag_offset_y = event.y - cy
+
+    def _on_canvas_drag(self, event):
+        if not self.dragging:
+            return
+        new_cx = event.x - self.drag_offset_x
+        new_cy = event.y - self.drag_offset_y
+        # Clamp to canvas bounds
+        new_cx = max(0, min(new_cx, self.CANVAS_W))
+        new_cy = max(0, min(new_cy, self.CANVAS_H))
+        self.pos_x_var.set(new_cx / self.CANVAS_W)
+        self.pos_y_var.set(new_cy / self.CANVAS_H)
+        self._update_preview()
+
+    def _on_canvas_release(self, _event):
+        self.dragging = False
+
+    # ------------------------------------------------------------------
+    # Defaults / Load / Save
+    # ------------------------------------------------------------------
+    def _reset_defaults(self):
+        # Pick the system's default font as a sensible starting point
+        default = find_default_font()
+        if default:
+            self.font_var.set(default[0])
+        self.font_size_var.set(DEFAULT_FONT_SIZE)
+        self._set_color("font", DEFAULT_FONT_COLOR)
+        self._set_color("bg", DEFAULT_BG_COLOR)
+        self.corner_radius_var.set(DEFAULT_CORNER_RADIUS)
+        self.pos_x_var.set(DEFAULT_POS_X)
+        self.pos_y_var.set(DEFAULT_POS_Y)
+        self._update_preview()
+
+    def load_config(self):
+        if hasattr(self.config, "config"):
+            cfg = self.config.config
+        else:
+            cfg = self.config
+
+        hook = cfg.get("hook_style", {}) or {}
+
+        # Font selection: stored as both name and path; prefer name resolution
+        saved_name = hook.get("font_name")
+        saved_path = hook.get("font_path")
+
+        names = get_font_names()
+        if saved_name and saved_name in names:
+            self.font_var.set(saved_name)
+        elif saved_path:
+            from utils.font_scanner import get_name_for_path
+            name = get_name_for_path(saved_path)
+            if name:
+                self.font_var.set(name)
+            else:
+                default = find_default_font()
+                if default:
+                    self.font_var.set(default[0])
+        else:
+            default = find_default_font()
+            if default:
+                self.font_var.set(default[0])
+
+        self.font_size_var.set(hook.get("font_size", DEFAULT_FONT_SIZE))
+        self._set_color("font", hook.get("font_color", DEFAULT_FONT_COLOR))
+        self._set_color("bg", hook.get("bg_color", DEFAULT_BG_COLOR))
+        self.corner_radius_var.set(int(hook.get("corner_radius", DEFAULT_CORNER_RADIUS)))
+        self.pos_x_var.set(hook.get("position_x", DEFAULT_POS_X))
+        self.pos_y_var.set(hook.get("position_y", DEFAULT_POS_Y))
+
+        self.after(120, self._update_preview)
+
+    def save_settings(self):
+        if hasattr(self.config, "config"):
+            cfg = self.config.config
+        else:
+            cfg = self.config
+
+        font_name = self.font_var.get()
+        font_path = get_path_for_name(font_name) or ""
+
+        cfg["hook_style"] = {
+            "font_name": font_name,
+            "font_path": font_path,
+            "font_size": float(self.font_size_var.get()),
+            "font_color": self.font_color,
+            "bg_color": self.bg_color,
+            "corner_radius": int(self.corner_radius_var.get()),
+            "position_x": float(self.pos_x_var.get()),
+            "position_y": float(self.pos_y_var.get()),
+        }
+
+        if self.on_save_callback:
+            self.on_save_callback(cfg)
+
+        from tkinter import messagebox
+        messagebox.showinfo("Success", "Hook style settings saved!")
+        self.on_back()
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+def _is_valid_hex(value: str) -> bool:
+    if not value.startswith("#"):
+        return False
+    body = value[1:]
+    if len(body) not in (3, 6):
+        return False
+    try:
+        int(body, 16)
+        return True
+    except ValueError:
+        return False
+
+
+def _family_only(display_name: str) -> str:
+    """Strip trailing style words so Tk can match the family name."""
+    if not display_name:
+        return "Arial"
+    suffixes = (" Bold", " Italic", " Regular", " Light", " Medium", " Black",
+                " Thin", " Heavy", " Semibold", " ExtraBold", " ExtraLight")
+    name = display_name
+    changed = True
+    while changed:
+        changed = False
+        for s in suffixes:
+            if name.endswith(s):
+                name = name[: -len(s)].rstrip()
+                changed = True
+    return name or display_name

--- a/pages/settings_page.py
+++ b/pages/settings_page.py
@@ -71,11 +71,14 @@ class SettingsPage(ctk.CTkFrame):
         self._create_setting_card(cards_frame, 0, 2, "📁", "Output", "Output directory", "output")
         self._create_setting_card(cards_frame, 0, 3, "💧", "Watermark", "Video watermark", "watermark")
         
-        # Row 2: Credit Watermark, Repliz, YouTube API, About
+        # Row 2: Credit Watermark, Hook Style, Repliz, YouTube API
         self._create_setting_card(cards_frame, 1, 0, "📝", "Credit", "Channel name credit", "credit_watermark")
-        self._create_setting_card(cards_frame, 1, 1, "🎬", "Repliz", "Repliz integration", "repliz")
-        self._create_setting_card(cards_frame, 1, 2, "📺", "YouTube API", "YouTube OAuth", "youtube_api")
-        self._create_setting_card(cards_frame, 1, 3, "ℹ️", "About", "App info & updates", "about")
+        self._create_setting_card(cards_frame, 1, 1, "✨", "Hook Style", "Hook overlay design", "hook_style")
+        self._create_setting_card(cards_frame, 1, 2, "🎬", "Repliz", "Repliz integration", "repliz")
+        self._create_setting_card(cards_frame, 1, 3, "📺", "YouTube API", "YouTube OAuth", "youtube_api")
+
+        # Row 3: About
+        self._create_setting_card(cards_frame, 2, 0, "ℹ️", "About", "App info & updates", "about")
     
     def _create_setting_card(self, parent, row, col, icon, title, description, page_key):
         """Create a clickable settings card"""
@@ -135,6 +138,9 @@ class SettingsPage(ctk.CTkFrame):
         elif page_key == "credit_watermark":
             from pages.settings.credit_watermark_settings import CreditWatermarkSettingsSubPage
             CreditWatermarkSettingsSubPage(self.container, self.config, self._on_settings_saved, self.create_main_page)
+        elif page_key == "hook_style":
+            from pages.settings.hook_style_settings import HookStyleSettingsSubPage
+            HookStyleSettingsSubPage(self.container, self.config, self._on_settings_saved, self.create_main_page)
         elif page_key == "repliz":
             from pages.settings.repliz_settings import ReplizSettingsSubPage
             ReplizSettingsSubPage(self.container, self.config, self._on_settings_saved, self.create_main_page)

--- a/utils/font_scanner.py
+++ b/utils/font_scanner.py
@@ -1,0 +1,158 @@
+"""
+System font scanner.
+
+Scans installed TrueType/OpenType fonts on the host OS and returns a sorted
+list of (display_name, absolute_path) tuples. Results are cached on first
+access for the lifetime of the process.
+
+Used by the Hook Style settings page so users can pick any font that exists
+on their machine.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import List, Tuple, Optional
+
+# Cache (display_name, path) sorted by display name
+_FONT_CACHE: Optional[List[Tuple[str, str]]] = None
+# Reverse lookup: display_name -> path
+_NAME_TO_PATH: Optional[dict] = None
+# Forward lookup: path -> display_name
+_PATH_TO_NAME: Optional[dict] = None
+
+
+def _get_font_directories() -> List[Path]:
+    """Return list of directories to scan for fonts on the current platform."""
+    dirs: List[Path] = []
+
+    if sys.platform == "win32":
+        # System fonts
+        win_dir = os.environ.get("WINDIR", r"C:\Windows")
+        dirs.append(Path(win_dir) / "Fonts")
+        # Per-user fonts (Windows 10+)
+        local_app = os.environ.get("LOCALAPPDATA")
+        if local_app:
+            dirs.append(Path(local_app) / "Microsoft" / "Windows" / "Fonts")
+    elif sys.platform == "darwin":
+        dirs.extend([
+            Path("/System/Library/Fonts"),
+            Path("/System/Library/Fonts/Supplemental"),
+            Path("/Library/Fonts"),
+            Path.home() / "Library" / "Fonts",
+        ])
+    else:
+        # Linux / other unix
+        dirs.extend([
+            Path("/usr/share/fonts"),
+            Path("/usr/local/share/fonts"),
+            Path.home() / ".fonts",
+            Path.home() / ".local" / "share" / "fonts",
+        ])
+
+    return [d for d in dirs if d.exists()]
+
+
+def _read_font_name(path: Path) -> Optional[str]:
+    """Try to read the human-readable family/style name from a font file.
+
+    Falls back to the filename stem if Pillow can't open it.
+    """
+    try:
+        # Lazy import so utils/font_scanner can be imported in headless contexts
+        from PIL import ImageFont
+        font = ImageFont.truetype(str(path), 16)
+        family, style = font.getname()
+        if family and style and style.lower() != "regular":
+            return f"{family} {style}"
+        if family:
+            return family
+    except Exception:
+        pass
+    # Fallback: use filename stem, prettified
+    stem = path.stem
+    return stem.replace("_", " ").replace("-", " ").strip() or None
+
+
+def scan_system_fonts(refresh: bool = False) -> List[Tuple[str, str]]:
+    """Scan all installed fonts and return a sorted list of (name, path).
+
+    Results are cached. Pass refresh=True to rebuild the cache.
+    Only TTF/OTF/TTC are returned.
+    """
+    global _FONT_CACHE, _NAME_TO_PATH, _PATH_TO_NAME
+
+    if _FONT_CACHE is not None and not refresh:
+        return _FONT_CACHE
+
+    seen_names: dict = {}
+    suffixes = (".ttf", ".otf", ".ttc")
+
+    for font_dir in _get_font_directories():
+        try:
+            for entry in font_dir.rglob("*"):
+                if not entry.is_file():
+                    continue
+                if entry.suffix.lower() not in suffixes:
+                    continue
+                name = _read_font_name(entry)
+                if not name:
+                    continue
+                # Prefer first occurrence; skip duplicates by display name
+                if name not in seen_names:
+                    seen_names[name] = str(entry)
+        except (PermissionError, OSError):
+            # Some directories may be inaccessible; skip silently
+            continue
+
+    items = sorted(seen_names.items(), key=lambda kv: kv[0].lower())
+    _FONT_CACHE = items
+    _NAME_TO_PATH = dict(items)
+    _PATH_TO_NAME = {v: k for k, v in items}
+    return items
+
+
+def get_font_names() -> List[str]:
+    """Return just the display names, sorted."""
+    return [name for name, _ in scan_system_fonts()]
+
+
+def get_path_for_name(name: str) -> Optional[str]:
+    """Resolve a display name to its file path. Returns None if not found."""
+    if _NAME_TO_PATH is None:
+        scan_system_fonts()
+    return _NAME_TO_PATH.get(name) if _NAME_TO_PATH else None
+
+
+def get_name_for_path(path: str) -> Optional[str]:
+    """Resolve a font file path back to its display name."""
+    if _PATH_TO_NAME is None:
+        scan_system_fonts()
+    return _PATH_TO_NAME.get(path) if _PATH_TO_NAME else None
+
+
+def find_default_font() -> Optional[Tuple[str, str]]:
+    """Best-effort default: pick a common bold sans-serif if present."""
+    preferred = [
+        "Arial Bold",
+        "Arial",
+        "Segoe UI Bold",
+        "Segoe UI",
+        "Helvetica Bold",
+        "Helvetica",
+        "DejaVu Sans Bold",
+        "DejaVu Sans",
+        "Liberation Sans Bold",
+        "Liberation Sans",
+    ]
+    fonts = scan_system_fonts()
+    name_map = {n: p for n, p in fonts}
+    for name in preferred:
+        if name in name_map:
+            return name, name_map[name]
+    # Fallback: first font we found, or None
+    if fonts:
+        return fonts[0]
+    return None

--- a/webview_app.py
+++ b/webview_app.py
@@ -120,6 +120,7 @@ class WebAPI:
         tts_model = cfg.get("tts_model", "tts-1")
         watermark_settings = cfg.get("watermark", {"enabled": False})
         credit_watermark_settings = cfg.get("credit_watermark", {"enabled": False})
+        hook_style_settings = cfg.get("hook_style", {})
         face_tracking_mode = cfg.get("face_tracking_mode", "opencv")
         mediapipe_settings = cfg.get("mediapipe_settings", {
             "lip_activity_threshold": 0.15,
@@ -142,6 +143,7 @@ class WebAPI:
             system_prompt=system_prompt,
             watermark_settings=watermark_settings,
             credit_watermark_settings=credit_watermark_settings,
+            hook_style_settings=hook_style_settings,
             face_tracking_mode=face_tracking_mode,
             mediapipe_settings=mediapipe_settings,
             ai_providers=ai_providers,


### PR DESCRIPTION
Adds a new 'Hook Style' settings sub-page that lets users customize the opening hook overlay:

- Font family from any installed system font (scanned via PIL)

- Font size (as fraction of video width)

- Font color and background color (hex picker)

- Corner radius in pixels (0 = sharp, matches old style)

- Position via drag-and-drop on a 9:16 preview canvas

Hook rendering in clipper_core is refactored from per-frame OpenCV cv2.putText to a single-pass PIL overlay composited via FFmpeg, which supports TTF fonts and rounded_rectangle natively. Defaults match the previous hard-coded look (white BG, gold text, sharp corners) so existing users see no visual change until they customize.