### PR TITLE
Fix OpenCV crash when Haar cascade fails to load

### DIFF
--- a/clipper_core.py
+++ b/clipper_core.py
@@ -2749,9 +2749,9 @@ Transcript:
         out_w, out_h = 1080, 1920
         
         # Face detector
-        face_cascade = cv2.CascadeClassifier(
-            cv2.data.haarcascades + 'haarcascade_frontalface_default.xml'
-        )
+        cascade_path = cv2.data.haarcascades + 'haarcascade_frontalface_default.xml'
+        face_cascade = cv2.CascadeClassifier(cascade_path)
+        use_face_detection = not face_cascade.empty()
         
         # First pass: analyze frames
         crop_positions = []
@@ -2763,7 +2763,7 @@ Transcript:
                 break
             
             gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
-            faces = face_cascade.detectMultiScale(gray, 1.1, 5, minSize=(50, 50))
+            faces = face_cascade.detectMultiScale(gray, 1.1, 5, minSize=(50, 50)) if use_face_detection else []
             
             if len(faces) > 0:
                 # Find largest face
@@ -3674,9 +3674,13 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
         out_w, out_h = 1080, 1920
         
         # Face detector
-        face_cascade = cv2.CascadeClassifier(
-            cv2.data.haarcascades + 'haarcascade_frontalface_default.xml'
-        )
+        cascade_path = cv2.data.haarcascades + 'haarcascade_frontalface_default.xml'
+        face_cascade = cv2.CascadeClassifier(cascade_path)
+        use_face_detection = not face_cascade.empty()
+        if not use_face_detection:
+            self.log(f"  ⚠ Face cascade not loaded (path: {cascade_path}), falling back to center crop")
+            print(f"[DEBUG] Face cascade empty, using center crop fallback")
+            sys.stdout.flush()
         
         # First pass: analyze frames (0-40%)
         print("[DEBUG] Pass 1: Analyzing frames...")
@@ -3699,7 +3703,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
                 break
             
             gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
-            faces = face_cascade.detectMultiScale(gray, 1.1, 5, minSize=(50, 50))
+            faces = face_cascade.detectMultiScale(gray, 1.1, 5, minSize=(50, 50)) if use_face_detection else []
             
             if len(faces) > 0:
                 # Find largest face


### PR DESCRIPTION
This PR fixes a crash during portrait conversion caused by an empty OpenCV CascadeClassifier.

Error log

```
[2026-07-22 15:50:08] ERROR
Process selected highlights failed

Exception Type: error
Exception Message: OpenCV(5.0.0) ... error: 
(-215:Assertion failed) !empty() in function 
'cv::CascadeClassifier::detectMultiScale'

Traceback:
Traceback (most recent call last):
  File "...\app.py", line 1584, in 
  run_process_selected
    core.process_selected_highlights(
  File "...\clipper_core.py", line 4922, in 
  process_selected_highlights
    self.process_clip(video_path, highlight, i, 
    total_clips,
  File "...\clipper_core.py", line 2546, in 
  process_clip
    self.convert_to_portrait_with_progress(str
    (landscape_file), str(portrait_file),
  File "...\clipper_core.py", line 3634, in 
  convert_to_portrait_with_progress
    return self.
    convert_to_portrait_opencv_with_progress
    (input_path, output_path, progress_callback)
  File "...\clipper_core.py", line 3702, in 
  convert_to_portrait_opencv_with_progress
    faces = face_cascade.detectMultiScale(gray, 1.
    1, 5, minSize=(50, 50))
```
**Root cause**

- The Haar cascade XML was loaded without validation.
- When OpenCV failed to load the classifier, face_cascade was empty.
- Calling detectMultiScale on an empty classifier triggered the crash.
Changes

- Extracted the Haar cascade file path into a dedicated variable for readability.
- Added validation to check whether the face cascade loaded successfully.
- Returned an empty face list when cascade loading fails to avoid crashes.
- Added warning logs and debug prints for failed cascade loading.
- Updated face detection calls to execute only when the cascade is properly loaded.

Result
- The app now falls back safely instead of crashing when the cascade file cannot be loaded.
- Portrait conversion continues using center-crop behavior if face detection is unavailable.